### PR TITLE
Fixes /cards redirecting to the dashboard when the cards_access cookie is absent

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -144,14 +144,6 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  // Cards routes are intentionally entered from dashboard action only.
-  if (pathname.startsWith("/cards")) {
-    const cardsAccessCookie = request.cookies.get("cards_access")?.value;
-    if (cardsAccessCookie !== "1") {
-      return NextResponse.redirect(new URL("/dashboard", request.url));
-    }
-  }
-
   // If we get here, user has valid session and appropriate permissions
   return NextResponse.next();
 }

--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -5,9 +5,7 @@ export async function POST() {
   try {
     const cookieStore = await cookies();
 
-    // Clear auth/session state cookies
     cookieStore.delete("session");
-    cookieStore.delete("cards_access");
 
     return NextResponse.json({
       success: true,

--- a/src/app/cards/layout.tsx
+++ b/src/app/cards/layout.tsx
@@ -8,14 +8,9 @@ export default async function CardsLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   const cookieStore = await cookies();
   const sessionCookie = cookieStore.get("session")?.value;
-  const cardsAccess = cookieStore.get("cards_access")?.value;
 
   if (!sessionCookie) {
     redirect("/login");
-  }
-
-  if (cardsAccess !== "1") {
-    redirect("/dashboard");
   }
 
   const admin = await initAdmin();

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -127,7 +127,6 @@ export default function DashboardPage() {
   }, [searchQuery, users]);
 
   const handleGoToCards = () => {
-    document.cookie = "cards_access=1; Path=/; Max-Age=600; SameSite=Lax";
     router.push("/cards");
   };
 


### PR DESCRIPTION
**The issue:** Staff can't open the `/cards` page directly. Reaching it through the Header "Cards" nav, a bookmark, a page refresh, or a shared link bounces the user back to `/dashboard`. The only way in is clicking the dashboard's "ARC Cards" button.

**The bug:** Access to `/cards` is gated behind a temporary `cards_access=1` cookie that only the dashboard's "ARC Cards" action sets, and it expires after 10 minutes. Both `middleware.ts` and `cards/layout.tsx` redirect to `/dashboard` whenever that cookie is missing or expired. As a result, direct navigation, a refresh after the cookie expires, or any entry that does not go through the dashboard fails, even though the user is already authenticated staff.

**The fix:** Remove the `cards_access` cookie gate entirely. `/cards` stays protected by the existing staff authentication in `middleware.ts` (it already lives in `STAFF_ONLY_ROUTES`), so it remains secure while becoming reachable like any other staff route. This removes the gate in `middleware.ts` and `cards/layout.tsx`, the cookie set in the dashboard's `handleGoToCards`, and the cookie cleanup on logout.
